### PR TITLE
[hotfix] 초기 토픽 10개 조회 기능 구현

### DIFF
--- a/backend/src/main/java/com/springboot/domain/topic/repository/TopicRepository.java
+++ b/backend/src/main/java/com/springboot/domain/topic/repository/TopicRepository.java
@@ -31,4 +31,7 @@ public interface TopicRepository extends JpaRepository<Topic, Long> {
         + "limit 10", nativeQuery = true)
     List<Topic> getTop10Topics();
 
+    @Query(value = "select * from topic order by id desc limit :num", nativeQuery = true)
+    List<Topic> getTopicsBelow10OrderById(@Param("num") int num);
+
 }

--- a/backend/src/main/java/com/springboot/domain/topic/service/TopicServiceImpl.java
+++ b/backend/src/main/java/com/springboot/domain/topic/service/TopicServiceImpl.java
@@ -53,6 +53,10 @@ public class TopicServiceImpl implements TopicService {
 
         List<Topic> topicList = topicRepository.getTop10Topics();
 
+        int necessaryNum = 10 - topicList.size();
+
+        topicList.addAll(topicRepository.getTopicsBelow10OrderById(necessaryNum));
+
         return topicList.stream().map(T -> entityToDTO(T))
             .collect(Collectors.toList());
     }

--- a/backend/src/test/java/com/springboot/domain/topic/TopicRepositoryTest.java
+++ b/backend/src/test/java/com/springboot/domain/topic/TopicRepositoryTest.java
@@ -48,6 +48,28 @@ public class TopicRepositoryTest {
 //
 //    }
 
+    @DisplayName("[Repository] 최신순 토픽 목록 모두 조회")
+    @Test
+    @Transactional
+    public void testFindAllTopicOrderById() {
+
+        List<Topic> topics = topicRepository.findAllByOrderByIdDesc();
+
+        topics.forEach(t -> logger.info(t.toString()));
+
+    }
+
+    @DisplayName("[Repository] 최신순 토픽 10개 이하 목록 조회")
+    @Test
+    @Transactional
+    public void testFindBelow10TopicOrderById() {
+
+        List<Topic> topics = topicRepository.getTopicsBelow10OrderById(10);
+
+        topics.forEach(t -> logger.info(t.toString()));
+
+    }
+
     @DisplayName("[Repository] keyword 포함한 name 가진 토픽 목록 조회")
     @Test
     @Transactional


### PR DESCRIPTION
### 관련 이슈
https://github.com/dnd-side-project/dnd-6th-10-a-piece-of-writing/issues/52

### 주요 내용
카테고리에 데이터가 없는 상태에서, 초기 토픽 10개 조회 기능 및 테스트 코드 구현